### PR TITLE
Add an option to use raw mode, allows for much larger data captures

### DIFF
--- a/src/pymso5000/mso5000.py
+++ b/src/pymso5000/mso5000.py
@@ -420,7 +420,7 @@ class MSO5000(Oscilloscope):
 
     def _query_waveform(self, channel, stats = None):
         """ When raw mode is enabled, the number of points is set by the scope's memory depth setting
-            This will generally take significantly longer as the memroy depth is much larger """
+            This will generally take significantly longer as the memory depth is much larger """
 
         if isinstance(channel, list) or isinstance(channel, tuple):
             resp = None


### PR DESCRIPTION
Hey, thanks for making this. It would be great if we could use the raw option mode on the scope so we can gather much larger amounts of samples. 1000 is too limiting in my case, raw mode lets you use up to the scope's memory depth.